### PR TITLE
Don't change CWD on launch

### DIFF
--- a/projects/haiku/ecode/AppRun
+++ b/projects/haiku/ecode/AppRun
@@ -1,6 +1,5 @@
 #!/bin/sh
 CANONPATH=$(readlink -f "$0")
 DIRPATH="$(dirname "$CANONPATH")"
-cd "$DIRPATH" || exit
 
-LD_LIBRARY_PATH=./libs ./ecode.bin "$@"
+LD_LIBRARY_PATH="$DIRPATH/libs" "$DIRPATH/ecode.bin" "$@"

--- a/projects/linux/ecode/AppRun
+++ b/projects/linux/ecode/AppRun
@@ -1,6 +1,5 @@
 #!/bin/sh
 CANONPATH=$(readlink -f "$0")
 DIRPATH="$(dirname "$CANONPATH")"
-cd "$DIRPATH" || exit
 
-LD_LIBRARY_PATH=./libs ./ecode.bin "$@"
+LD_LIBRARY_PATH="$DIRPATH/libs" "$DIRPATH/ecode.bin" "$@"


### PR DESCRIPTION
Changing CWD on launch prevents opening files/directories with relative paths.

e.g.:
```
cd /my/project
ecode test.c
```
...will open an empty file in ecode's install dir (e.g. `/opt/ecode/test.c`) instead of `/my/project/test.c`.