### PR TITLE
enable arm64 for non-iOS devices

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -683,7 +683,7 @@ workspace "eepp"
 		platforms { "x86_64", "arm64" }
 	else
 		configurations { "debug", "release" }
-		platforms { "x86_64", "x86" }
+		platforms { "x86_64", "x86", "arm64" }
 	end
 	rtti "On"
 	download_and_extract_dependencies()


### PR DESCRIPTION
This application is also useful for arm64 non-iOS devices. Since I'm submitting ecode to flathub.org, it would be nice to include the arm64 architecture as flathub.org supports it.