### PR TITLE
adding support for optional col with `:` separator

### DIFF
--- a/src/tools/ecode/universallocator.cpp
+++ b/src/tools/ecode/universallocator.cpp
@@ -225,10 +225,11 @@ void UniversalLocator::initLocateBar( UILocateBar* locateBar, UITextInput* locat
 	mLocateTable->setHeadersVisible( false );
 	mLocateTable->setVisible( false );
 	mLocateInput->addEventListener( Event::OnTextChanged, [&]( const Event* ) {
-		const String& txt = mLocateInput->getText();
-		if ( mSplitter->curEditorExistsAndFocused() && String::startsWith( txt, String( "l " ) ) ) {
-			String txtSubstring( txt.substr( 2 ) );
-			std::vector<String> parts = txtSubstring.split( ':' );
+		const String& input = mLocateInput->getText();
+		if ( mSplitter->curEditorExistsAndFocused() &&
+			 String::startsWith( input, String( "l " ) ) ) {
+			String lineColInput( input.substr( 2 ) );
+			std::vector<String> parts = lineColInput.split( ':' );
 			Int64 line, column = 0;
 
 			if ( parts.size() > 0 && String::fromString( line, parts[0] ) && line - 1 >= 0 ) {
@@ -243,11 +244,11 @@ void UniversalLocator::initLocateBar( UILocateBar* locateBar, UITextInput* locat
 				}
 				mLocateTable->setVisible( false );
 			}
-		} else if ( !txt.empty() && mLocateInput->getText()[0] == '>' ) {
+		} else if ( !input.empty() && mLocateInput->getText()[0] == '>' ) {
 			showCommandPalette();
-		} else if ( !txt.empty() && mLocateInput->getText()[0] == ':' ) {
+		} else if ( !input.empty() && mLocateInput->getText()[0] == ':' ) {
 			showWorkspaceSymbol();
-		} else if ( String::startsWith( txt, ". " ) ) {
+		} else if ( String::startsWith( input, ". " ) ) {
 			showDocumentSymbol();
 		} else {
 			showLocateTable();

--- a/src/tools/ecode/universallocator.cpp
+++ b/src/tools/ecode/universallocator.cpp
@@ -225,10 +225,10 @@ void UniversalLocator::initLocateBar( UILocateBar* locateBar, UITextInput* locat
 	mLocateTable->setHeadersVisible( false );
 	mLocateTable->setVisible( false );
 	mLocateInput->addEventListener( Event::OnTextChanged, [&]( const Event* ) {
-		const String& input = mLocateInput->getText();
+		const String& inputTxt = mLocateInput->getText();
 		if ( mSplitter->curEditorExistsAndFocused() &&
-			 String::startsWith( input, String( "l " ) ) ) {
-			String lineColInput( input.substr( 2 ) );
+			 String::startsWith( inputTxt, String( "l " ) ) ) {
+			String lineColInput( inputTxt.substr( 2 ) );
 			std::vector<String> parts = lineColInput.split( ':' );
 			Int64 line, column = 0;
 
@@ -244,11 +244,11 @@ void UniversalLocator::initLocateBar( UILocateBar* locateBar, UITextInput* locat
 				}
 				mLocateTable->setVisible( false );
 			}
-		} else if ( !input.empty() && mLocateInput->getText()[0] == '>' ) {
+		} else if ( !inputTxt.empty() && mLocateInput->getText()[0] == '>' ) {
 			showCommandPalette();
-		} else if ( !input.empty() && mLocateInput->getText()[0] == ':' ) {
+		} else if ( !inputTxt.empty() && mLocateInput->getText()[0] == ':' ) {
 			showWorkspaceSymbol();
-		} else if ( String::startsWith( input, ". " ) ) {
+		} else if ( String::startsWith( inputTxt, ". " ) ) {
 			showDocumentSymbol();
 		} else {
 			showLocateTable();

--- a/src/tools/ecode/universallocator.cpp
+++ b/src/tools/ecode/universallocator.cpp
@@ -227,11 +227,20 @@ void UniversalLocator::initLocateBar( UILocateBar* locateBar, UITextInput* locat
 	mLocateInput->addEventListener( Event::OnTextChanged, [&]( const Event* ) {
 		const String& txt = mLocateInput->getText();
 		if ( mSplitter->curEditorExistsAndFocused() && String::startsWith( txt, String( "l " ) ) ) {
-			String number( txt.substr( 2 ) );
-			Int64 val;
-			if ( String::fromString( val, number ) && val - 1 >= 0 ) {
-				if ( mSplitter->curEditorExistsAndFocused() )
-					mSplitter->getCurEditor()->goToLine( { val - 1, 0 } );
+			String txtSubstring( txt.substr( 2 ) );
+			std::vector<String> parts = txtSubstring.split( ':' );
+			Int64 line, column = 0;
+
+			if ( parts.size() > 0 && String::fromString( line, parts[0] ) && line - 1 >= 0 ) {
+				if ( parts.size() > 1 ) {
+					String::fromString( column, parts[1] );
+					if ( column < 0 ) {
+						column = 0;
+					}
+				}
+				if ( mSplitter->curEditorExistsAndFocused() ) {
+					mSplitter->getCurEditor()->goToLine( { line - 1, column } );
+				}
 				mLocateTable->setVisible( false );
 			}
 		} else if ( !txt.empty() && mLocateInput->getText()[0] == '>' ) {


### PR DESCRIPTION
This takes the `go to line` command a step further by adding optional column support. 

Now it can accept and of the following

`l 25` -> Takes the user to line 25 (Pre-existing implementation)
`l 25:32` -> Takes the user to line 25 and col 32