### PR TITLE
Modify the position/dimensions of the lsp tooltip displayed during hover

### DIFF
--- a/include/eepp/ui/uitooltip.hpp
+++ b/include/eepp/ui/uitooltip.hpp
@@ -121,6 +121,8 @@ class EE_API UITooltip : public UIWidget {
 
 	void notifyTextChangedFromTextCache();
 
+	void wrapText( Uint32 width );
+
   protected:
 	Text* mTextCache;
 	UIFontStyleConfig mStyleConfig;

--- a/src/eepp/ui/uitooltip.cpp
+++ b/src/eepp/ui/uitooltip.cpp
@@ -578,4 +578,8 @@ void UITooltip::onAlphaChange() {
 	mTextCache->setOutlineColor( outlineColor );
 }
 
+void UITooltip::wrapText( Uint32 width ) {
+	mTextCache->wrapText( width );
+}
+
 }} // namespace EE::UI

--- a/src/tools/ecode/plugins/lsp/lspclientplugin.cpp
+++ b/src/tools/ecode/plugins/lsp/lspclientplugin.cpp
@@ -1453,7 +1453,7 @@ void LSPClientPlugin::displayTooltip( UICodeEditor* editor, const LSPHover& resp
 		mOldBackgroundColor = tooltip->getBackgroundColor();
 	}
 	tooltip->setHorizontalAlign( UI_HALIGN_LEFT );
-	tooltip->setPixelsPosition( tooltip->getTooltipPosition( position ) );
+	tooltip->setPixelsPosition( position );
 	tooltip->setDontAutoHideOnMouseMove( true );
 	tooltip->setUsingCustomStyling( true );
 	tooltip->setFontStyle( Text::Regular );
@@ -1467,6 +1467,7 @@ void LSPClientPlugin::displayTooltip( UICodeEditor* editor, const LSPHover& resp
 	if ( tooltip->getText().empty() )
 		return;
 
+	tooltip->wrapText( editor->getSize().getWidth() / 2.0 );
 	const auto& syntaxDef = resp.contents[0].kind == LSPMarkupKind::MarkDown
 								? SyntaxDefinitionManager::instance()->getByLSPName( "markdown" )
 								: editor->getSyntaxDefinition();


### PR DESCRIPTION
Hello,

I'm using the ecode editor and I noticed that when I hover in the document, the tooltip containing the lsp info is not properly displayed. If it's too much information it can even cover the whole editor area and that can be annoying.

You can see what I mean in this screenshot:

![old](https://github.com/SpartanJ/eepp/assets/30523683/587bee88-5d53-4941-9b02-d581b3b20743)


I'm not familiar with this project or c++, but I've done some research and I've implemented a fix to take smaller space.
You can see an example here:

![new](https://github.com/SpartanJ/eepp/assets/30523683/c9b3aa7e-49f5-4639-90b1-740731e4e788)


Thank you for your work on this project! :+1: 
