### PR TITLE
Update lspclient.json to make the Haskell LSP work

### DIFF
--- a/bin/assets/plugins/lspclient.json
+++ b/bin/assets/plugins/lspclient.json
@@ -245,7 +245,7 @@
       "language": "haskell",
       "name": "haskell-language-server",
       "url": "https://github.com/haskell/haskell-language-server",
-      "command": "haskell-language-server-wrapper",
+      "command": "haskell-language-server-wrapper --lsp",
       "file_patterns": ["%.hs$"],
       "rootIndicationFileNames": ["%.cabal$", "stack.yaml", "cabal.project", "package.yaml", "hie.yaml"]
     },


### PR DESCRIPTION
The haskell language server executable must be called with the `--lsp` flag to operate as an lsp server.

I tested this with ecode 0.5.2. The LSP does not work out of the box, but requires this change in the `lspclient.json` file.