### PR TITLE
DiscordRPCPlugin: :sparkles: Git origin repository button

### DIFF
--- a/src/tools/ecode/plugins/discordRPC/discordRPCplugin.hpp
+++ b/src/tools/ecode/plugins/discordRPC/discordRPCplugin.hpp
@@ -28,7 +28,7 @@ class DiscordRPCplugin : public PluginBase {
 				 "Discord Rich Presence",
 				 "Show your friends what you are up to through the discord Rich Presence system",
 				 DiscordRPCplugin::New,
-				 { 0, 0, 1 },
+				 { 0, 0, 2 },
 				 DiscordRPCplugin::NewSync };
 	}
 

--- a/src/tools/ecode/plugins/discordRPC/discordRPCplugin.hpp
+++ b/src/tools/ecode/plugins/discordRPC/discordRPCplugin.hpp
@@ -3,6 +3,7 @@
 
 #include "../plugin.hpp"
 #include "../pluginmanager.hpp"
+#include "../git/gitplugin.hpp"
 
 #include <eepp/system/filesystem.hpp>
 #include <eepp/system/mutex.hpp>
@@ -46,12 +47,17 @@ class DiscordRPCplugin : public PluginBase {
   protected:
 	DiscordIPC mIPC;
 	Mutex mDataMutex;
+	GitPlugin* mGitPlugin{ nullptr };
+
 	std::string mLastFile;
 	std::string mLastLang;
 	std::string mLastLangName;
 	std::string mProjectName;
+	std::string mProjectPath;
 	nlohmann::json mLangBindings;
+	PluginManager* mPluginManager{ nullptr };
 	bool mDoLangIcon;
+	bool mDoGitIntegration;
 
 	void load( PluginManager* pluginManager );
 
@@ -70,7 +76,7 @@ class DiscordRPCplugin : public PluginBase {
 
 	void initIPC();
 
-	void udpateActivity( DiscordIPCActivity& a );
+	void updateActivity( DiscordIPCActivity& a );
 };
 
 } // namespace ecode

--- a/src/tools/ecode/plugins/git/gitplugin.hpp
+++ b/src/tools/ecode/plugins/git/gitplugin.hpp
@@ -76,10 +76,13 @@ class GitPlugin : public PluginBase {
 	void updateRepos();
 
 	bool isSilent() const { return mSilent; }
+	
+	std::unique_ptr<Git> mGit;
+	bool mGitFound{ false };
 
   protected:
-	std::unique_ptr<Git> mGit;
 	std::unordered_map<std::string, std::string> mGitBranches;
+	bool mInitialized{ false };
 	Git::Status mGitStatus;
 	std::vector<std::pair<std::string, std::string>> mRepos;
 	UnorderedSet<std::string> mGitStatusFilesCache;
@@ -88,7 +91,6 @@ class GitPlugin : public PluginBase {
 	std::string mHighlightStyleColor;
 
 	Time mRefreshFreq{ Seconds( 5 ) };
-	bool mGitFound{ false };
 	bool mTooltipInfoShowing{ false };
 	bool mStatusBarDisplayBranch{ true };
 	bool mStatusBarDisplayModifications{ true };
@@ -96,7 +98,6 @@ class GitPlugin : public PluginBase {
 	bool mFileTreeHighlightChanges{ true };
 	bool mOldDontAutoHideOnMouseMove{ false };
 	bool mOldUsingCustomStyling{ false };
-	bool mInitialized{ false };
 	bool mSilent{ true };
 	Uint32 mOldTextStyle{ 0 };
 	Uint32 mOldTextAlign{ 0 };

--- a/src/tools/ecode/plugins/git/gitplugin.hpp
+++ b/src/tools/ecode/plugins/git/gitplugin.hpp
@@ -82,7 +82,6 @@ class GitPlugin : public PluginBase {
 
   protected:
 	std::unordered_map<std::string, std::string> mGitBranches;
-	bool mInitialized{ false };
 	Git::Status mGitStatus;
 	std::vector<std::pair<std::string, std::string>> mRepos;
 	UnorderedSet<std::string> mGitStatusFilesCache;
@@ -98,6 +97,7 @@ class GitPlugin : public PluginBase {
 	bool mFileTreeHighlightChanges{ true };
 	bool mOldDontAutoHideOnMouseMove{ false };
 	bool mOldUsingCustomStyling{ false };
+	bool mInitialized{ false };
 	bool mSilent{ true };
 	Uint32 mOldTextStyle{ 0 };
 	Uint32 mOldTextAlign{ 0 };


### PR DESCRIPTION
Added a feature which displays a "repository" button for the git origin url with `.git` suffix trimmed. It checks for `mDoGitIntegration` value in config.

it does NOT check if the url leads to a valid page (which might be the case with some git hosts) but that would require an http request and might be too heavy?? (if you think it should be implemented I can try tho)

Due to the way discord works it does not show the buttons to the user creating the RPC which is annoying (see [comment in ipc.hpp](https://github.com/SpartanJ/eepp/blob/62d3a4152735816e08cd63664aebe3c381628775/src/tools/ecode/plugins/discordRPC/sdk/ipc.hpp#L36-L38))