### PR TITLE
Ecode - support debugging Ü code.

### DIFF
--- a/bin/assets/plugins/debugger.json
+++ b/bin/assets/plugins/debugger.json
@@ -8,7 +8,7 @@
         "command": "gdb",
         "command_arguments": "--interpreter=dap"
       },
-      "languages": [ "cpp", "c", "d", "go", "objectivec", "fortran", "pascal", "rust" ],
+      "languages": [ "cpp", "c", "d", "go", "objectivec", "fortran", "pascal", "rust", "ü" ],
       "configurations": [
         {
           "name": "Launch binary",
@@ -48,7 +48,7 @@
       "find": {
         "macos": "xcrun -f ${command}"
       },
-      "languages": [ "cpp", "c", "odin", "rust", "zig" ],
+      "languages": [ "cpp", "c", "odin", "rust", "zig", "ü" ],
       "configurations": [
         {
           "name": "Launch binary",


### PR DESCRIPTION
Mention Ü in supported languages of _gdb_ and _lldb_.

_gdb_ isn't properly tested, since I have a pretty old version without DAP support, but I see no reason why it shouldn't work. But adding/removing breakpoints works.

Debugging with _lldb-dap_ (_lldb-vscode_) works  fine:
![Снимок экрана_2025-04-09_15-19-54](https://github.com/user-attachments/assets/1ec18a20-8595-4845-9b01-2323760494dd)
