### PR TITLE
For "ecode" set on startup window title to "ecode".

### DIFF
--- a/src/tools/ecode/ecode.cpp
+++ b/src/tools/ecode/ecode.cpp
@@ -3511,6 +3511,7 @@ void App::init( const LogLevel& logLevel, std::string file, const Float& pidelDe
 	Engine* engine = Engine::instance();
 
 	WindowSettings winSettings = engine->createWindowSettings( &mConfig.iniState, "window" );
+	winSettings.Title = "ecode";
 	winSettings.PixelDensity = 1;
 	winSettings.Width = mConfig.windowState.size.getWidth();
 	winSettings.Height = mConfig.windowState.size.getHeight();


### PR DESCRIPTION
This prevents displaying ecode as "unnamed window" in XUbuntu task manager (and maybe in other similar software).