### PR TITLE
added curry language definition for syntax highlighting

### DIFF
--- a/projects/linux/ee.files
+++ b/projects/linux/ee.files
@@ -911,6 +911,8 @@
 ../../src/eepp/ui/doc/languages/csharp.hpp
 ../../src/eepp/ui/doc/languages/css.cpp
 ../../src/eepp/ui/doc/languages/css.hpp
+../../src/eepp/ui/doc/languages/curry.cpp
+../../src/eepp/ui/doc/languages/curry.hpp
 ../../src/eepp/ui/doc/languages/d.cpp
 ../../src/eepp/ui/doc/languages/d.hpp
 ../../src/eepp/ui/doc/languages/dart.cpp

--- a/projects/macos/ee.files
+++ b/projects/macos/ee.files
@@ -971,6 +971,8 @@
 ../../src/eepp/ui/doc/languages/csharp.cpp
 ../../src/eepp/ui/doc/languages/csharp.hpp
 ../../src/eepp/ui/doc/languages/css.cpp
+../../src/eepp/ui/doc/languages/curry.cpp
+../../src/eepp/ui/doc/languages/curry.hpp
 ../../src/eepp/ui/doc/languages/d.cpp
 ../../src/eepp/ui/doc/languages/dart.cpp
 ../../src/eepp/ui/doc/languages/dart.hpp

--- a/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languages/curry.cpp
+++ b/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languages/curry.cpp
@@ -1,0 +1,42 @@
+#include <eepp/ui/doc/languages/curry.hpp>
+#include <eepp/ui/doc/syntaxdefinitionmanager.hpp>
+
+namespace EE { namespace UI { namespace Doc { namespace Language {
+
+SyntaxDefinition& addCurry() {
+
+	return SyntaxDefinitionManager::instance()->add(
+
+		{ "Curry",
+		  { "%.curry$" },
+		  {
+			  { { "%-%-", "\n" }, "comment" },
+			  { { "{%-", "%-}" }, "comment" },
+			  { { "\"", "\"", "\\" }, "string" },
+			  { { "'", "'", "\\" }, "string" },
+			  { { "-?0x%x+" }, "number" },
+			  { { "-?%d+[%d%.eE]*f?" }, "number" },
+			  { { "-?%.?%d+f?" }, "number" },
+			  { { "[!%#%$%%&*+./%<=>%?@\\%^|%-~:]" }, "operator" },
+			  { { "[%a_'][%w_']*" }, "symbol" },
+
+		  },
+		  {
+			  { "in", "keyword" },		 { "then", "keyword" },	  { "default", "keyword" },
+			  { "mdo", "keyword" },		 { "forall", "keyword" }, { "hiding", "keyword" },
+			  { "data", "keyword" },	 { "import", "keyword" }, { "as", "keyword" },
+			  { "class", "keyword" },	 { "infixl", "keyword" }, { "newtype", "keyword" },
+			  { "of", "keyword" },		 { "module", "keyword" }, { "infix", "keyword" },
+			  { "deriving", "keyword" }, { "where", "keyword" },  { "else", "keyword" },
+			  { "foreign", "keyword" },	 { "infixr", "keyword" }, { "qualified", "keyword" },
+			  { "case", "keyword" },	 { "if", "keyword" },	  { "let", "keyword" },
+			  { "do", "keyword" },		 { "type", "keyword" },
+
+		  },
+		  "%-%-",
+		  {}
+
+		} );
+}
+
+}}}} // namespace EE::UI::Doc::Language

--- a/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languages/curry.hpp
+++ b/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languages/curry.hpp
@@ -1,0 +1,12 @@
+#ifndef EE_UI_DOC_Curry
+#define EE_UI_DOC_Curry
+
+#include <eepp/ui/doc/syntaxdefinition.hpp>
+
+namespace EE { namespace UI { namespace Doc { namespace Language {
+
+extern SyntaxDefinition& addCurry();
+
+}}}} // namespace EE::UI::Doc::Language
+
+#endif

--- a/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languagessyntaxhighlighting.cpp
+++ b/src/modules/languages-syntax-highlighting/src/eepp/ui/doc/languagessyntaxhighlighting.cpp
@@ -19,6 +19,7 @@
 #include <eepp/ui/doc/languages/covscript.hpp>
 #include <eepp/ui/doc/languages/crystal.hpp>
 #include <eepp/ui/doc/languages/csharp.hpp>
+#include <eepp/ui/doc/languages/curry.hpp>
 #include <eepp/ui/doc/languages/d.hpp>
 #include <eepp/ui/doc/languages/dart.hpp>
 #include <eepp/ui/doc/languages/difffile.hpp>
@@ -246,6 +247,12 @@ void LanguagesSyntaxHighlighting::load() {
 		{ "%.cs$", "%.csx$" },
 		{},
 		"csharp",
+	} );
+
+	sdm->addPreDefinition( {
+		"Curry",
+		[]() -> SyntaxDefinition& { return addCurry(); },
+		{ "%.curry$" },
 	} );
 
 	sdm->addPreDefinition( {


### PR DESCRIPTION
I'm working with [Curry](https://curry-lang.org/) recently. For syntax highlighting in ecode I added a `curry.json` file to `~/.config/ecode/languages/`. That works fine, but I will forget about this tweak soon. So I though I propose to add this language to ecode directly.

Curry is very similar to Haskell, so I just copied it's definition and modified it slightly.

Feel free to reject this PR, in case you consider Curry to niche, or if I did not do this correctly.

***

I also have a related question: Comments for Haskell or Elm are defined as `%-%-`. But that is not correct, should just be `--`. I set my .json file for these languages now to 

```json
{
  "comment": "--",
  "files": [
    "%.hs$"
  ],
  "name": "Haskell",
  "patterns": [
    {
      "pattern": [
        "%-%-",
        "\n"
      ],
      "type": "comment"
    },
    ...
```

That works fine for me. Should this also be the default setting?